### PR TITLE
MISC: update galaxy tools with manual install requirements

### DIFF
--- a/tools/jc_parser/README.txt
+++ b/tools/jc_parser/README.txt
@@ -1,3 +1,24 @@
+Johnson-Charniak Parser V1.0
+
+Requirements
+============
+
+Requires XFVB, TkInter and ImageMagick for displaying NLTK's parse trees.
+
+::
+
+	sudo apt-get install python-tk -y
+	sudo apt-get install imagemagick
+	sudo apt-get install xvfb -y
+	export DISPLAY=:1
+	Xvfb :1 -screen 0 1024x768x24 &
+	sudo xhost +
+	sudo echo "export DISPLAY=:1" >> ~/.bashrc
+
+
+Acknowledgements
+================
+
 This galaxy tool makes use of the 2015.07.23 release of the bllipparser. 
 Eugene Charniak and Mark Johnson. "Coarse-to-fine n-best parsing and MaxEnt discriminative reranking." Proceedings of the 43rd Annual Meeting on Association for Computational Linguistics. Association for Computational Linguistics, 2005.
 

--- a/tools/psysound/README.txt
+++ b/tools/psysound/README.txt
@@ -3,12 +3,12 @@ PsySound V1.0
 Requirements
 ============
 
-Requires libxt-dev and libxmu-dev
+Requires libxt-dev, libxmu-dev and the matlab compiler runtime.
 
 ::
 
-apt-get install libxt-dev
-apt-get install libxmu-dev
+sudo apt-get install libxt-dev
+sudo apt-get install libxmu-dev
 
 Formats Supported
 =================

--- a/tools/psysound/setup.sh
+++ b/tools/psysound/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sudo apt-get install libxt-dev
+sudo apt-get install libxmu-dev


### PR DESCRIPTION
Modified jc parser and psysyound readme to include all of the required manual installation steps as instructions. These README files are automatically displayed in Galaxy when selecting to install a tool from the toolshed. Also included a setup script for psysound which mirrors the steps included in the README file.
