### PR TITLE
HCSVLAB-1012: add JC-Parser attribution in Galaxy

### DIFF
--- a/tools/jc_parser/JCParser.xml
+++ b/tools/jc_parser/JCParser.xml
@@ -21,9 +21,9 @@
 	<options refresh="True"/>
 	<help>
 	<![CDATA[
-
 	Input is sentence segmented text. Run the J-C Parser over the text with default settings, output is a bracketed parse tree for the sentences.
 
+	This tool makes use of the 2015.07.23 release of the bllipparser. The BLLIP parser (also known as the Charniak-Johnson parser or Brown Reranking Parser) is described in the paper by Charniak and Johnson (Eugene Charniak and Mark Johnson. "Coarse-to-fine n-best parsing and MaxEnt discriminative reranking." Proceedings of the 43rd Annual Meeting on Association for Computational Linguistics. Association for Computational Linguistics, 2005). The authors request acknowledgement in any publications that make use of this software and any code derived from this software. Please report the release date of the software that you are using, as this will enable others to compare their results to yours.
 	]]>
 	</help>
 </tool>


### PR DESCRIPTION
Add attribution so that users should be made aware that they should acknowledge the use of the JC-Parser if they use it for research purposes.
