### PR TITLE
HCSVLAB-1013: update parseEval dependencies

### DIFF
--- a/tool_dependencies/package_r_gridExtra_2_0_0/tool_dependencies.xml
+++ b/tool_dependencies/package_r_gridExtra_2_0_0/tool_dependencies.xml
@@ -3,11 +3,14 @@
       <package name="R" version="3.1.2">
           <repository name="package_r_3_1_2" owner="iuc" prior_installation_required="True"/>
       </package>
-      <package name="R_lattice" version="0.20.31">
+      <package name="R_gridExtra" version="2.0.0">
           <install version="1.0">
               <actions>
                   <action type="setup_r_environment">
-                      <package>http://cran.ms.unimelb.edu.au/src/contrib/lattice_0.20-31.tar.gz</package>
+                      <repository name="package_r_3_1_2" owner="iuc">
+                          <package name="R" version="3.1.2"/>
+                      </repository>
+                      <package>http://cran.ms.unimelb.edu.au/src/contrib/gridExtra_2.0.0.tar.gz</package>
                   </action>
               </actions>
           </install>

--- a/tool_dependencies/package_r_latticeExtra_0_6_26/tool_dependencies.xml
+++ b/tool_dependencies/package_r_latticeExtra_0_6_26/tool_dependencies.xml
@@ -7,6 +7,9 @@
           <install version="1.0">
               <actions>
                   <action type="setup_r_environment">
+                      <repository name="package_r_3_1_2" owner="iuc">
+                          <package name="R" version="3.1.2"/>
+                      </repository>
                       <package>http://cran.ms.unimelb.edu.au/src/contrib/latticeExtra_0.6-26.tar.gz</package>
                   </action>
               </actions>

--- a/tool_dependencies/package_r_lattice_0_20_33/tool_dependencies.xml
+++ b/tool_dependencies/package_r_lattice_0_20_33/tool_dependencies.xml
@@ -3,11 +3,14 @@
       <package name="R" version="3.1.2">
           <repository name="package_r_3_1_2" owner="iuc" prior_installation_required="True"/>
       </package>
-      <package name="R_gridExtra" version="0.9.1">
+      <package name="R_lattice" version="0.20.33">
           <install version="1.0">
               <actions>
                   <action type="setup_r_environment">
-                      <package>http://cran.ms.unimelb.edu.au/src/contrib/gridExtra_0.9.1.tar.gz</package>
+                      <repository name="package_r_3_1_2" owner="iuc">
+                          <package name="R" version="3.1.2"/>
+                      </repository>
+                      <package>http://cran.ms.unimelb.edu.au/src/contrib/lattice_0.20-33.tar.gz</package>
                   </action>
               </actions>
           </install>

--- a/tools/parse_eval/ParseEval.xml
+++ b/tools/parse_eval/ParseEval.xml
@@ -8,9 +8,9 @@
     <requirements>
         <requirement type="set_environment">R_SCRIPT_PATH</requirement>
         <requirement type="package" version="3.1.2">R</requirement>
-        <requirement type="package" version="0.20.31">R_lattice</requirement>
+        <requirement type="package" version="0.20.33">R_lattice</requirement>
         <requirement type="package" version="0.6.26">R_latticeExtra</requirement>
-        <requirement type="package" version="0.9.1">R_gridExtra</requirement>
+        <requirement type="package" version="2.0.0">R_gridExtra</requirement>
     </requirements>
 
 	<inputs>
@@ -48,6 +48,10 @@
 	    		stop("Number of words must be divisible by the number of types without a remainder")
 	    	}
 
+	    	require(lattice , quietly=T)
+			require(latticeExtra , quietly=T)
+			require(gridExtra , quietly=T)
+	    	
 			args &lt;- commandArgs(trailingOnly = TRUE)
 	    	source(file.path(args[1], "parseval.R"))
 

--- a/tools/parse_eval/tool_dependencies.xml
+++ b/tools/parse_eval/tool_dependencies.xml
@@ -8,16 +8,16 @@
         <repository name="package_r_3_1_2" owner="iuc" prior_installation_required="True"/>
     </package>
 
-    <package name="R_lattice" version="0.20.31">
-        <repository name="package_r_lattice_0_20_31" owner="alveo" prior_installation_required="True"/>
+    <package name="R_lattice" version="0.20.33">
+        <repository name="package_r_lattice_0_20_33" owner="alveo" prior_installation_required="True"/>
     </package>
 
     <package name="R_latticeExtra" version="0.6.26">
         <repository name="package_r_lattice_extra_0_6_26" owner="alveo" prior_installation_required="True"/>
     </package>
 
-    <package name="R_gridExtra" version="0.9.1">
-        <repository name="package_r_grid_extra_0_9_1" owner="alveo" prior_installation_required="True"/>
+    <package name="R_gridExtra" version="2.0.0">
+        <repository name="package_r_grid_extra_2_0_0" owner="alveo" prior_installation_required="True"/>
     </package>
 
 </tool_dependency>


### PR DESCRIPTION
Update the versions of the lattice and gridExtra packages for R, as the older versions are not maintained and the old link is dead. Also include packages as R requirement.
