### PR TITLE
Revert tokenize tool to output one token per line 

### DIFF
--- a/tools/nltk_tools/g_tokenize.py
+++ b/tools/nltk_tools/g_tokenize.py
@@ -7,7 +7,7 @@ def arguments():
     parser = argparse.ArgumentParser(description="tokenize a text")
     parser.add_argument('--input', required=True, action="store", type=str, help="input text file")
     parser.add_argument('--output', required=True,  action="store", type=str, help="output file path")
-    parser.add_argument('--lower', required=False, action="store_true", help="lowercase all words")  
+    parser.add_argument('--lower', required=False, action="store_true", help="lowercase all words")
     parser.add_argument('--nopunct', required=False, action="store_true", help="remove all punctuation characters")
     args = parser.parse_args()
     return args
@@ -31,12 +31,13 @@ def tokenize(in_file, out_file, lower=False, nopunct=False):
         tokens = nltk.word_tokenize(sentence)
         result.append(tokens)
     output = open(out_file, 'w')
-    output.write(json.dumps(result, indent=4))
+    # write one token per line
+    for sentence in result:
+        for token in sentence:
+            output.write(token + "\n")
     output.close()
 
 
 if __name__ == '__main__':
     args = arguments()
     tokenize(args.input, args.output, lower=args.lower, nopunct=args.nopunct)
-    
-    

--- a/tools/nltk_tools/g_tokenize.xml
+++ b/tools/nltk_tools/g_tokenize.xml
@@ -20,26 +20,26 @@
                label="Remove punctuation?"/>
     </inputs>
     <outputs>
-        <data format="json" name="tokens" label="${input1.name} Tokens"/>
+        <data format="txt" name="tokens" label="${input1.name} Tokens"/>
     </outputs>
     <tests>
         <test>
             <param name='input1' value='sample_text.txt'/>
             <param name='lower' value='--lower'/>
             <param name='nopunct' value='--nopunct'/>
-            <output name='tokens' file='sample_text_lower_nopunct.json'/>
+            <output name='tokens' file='sample_text_lower_nopunct.txt'/>
         </test>
         <test>
             <param name='input1' value='sample_text.txt'/>
             <param name='lower' value='--lower'/>
             <param name='nopunct' value=''/>
-            <output name='tokens' file='sample_text_lower.json'/>
+            <output name='tokens' file='sample_text_lower.txt'/>
         </test>
         <test>
             <param name='input1' value='sample_text.txt'/>
             <param name='lower' value=''/>
             <param name='nopunct' value=''/>
-            <output name='tokens' file='sample_text_tok.json'/>
+            <output name='tokens' file='sample_text_tok.txt'/>
         </test>
 
     </tests>


### PR DESCRIPTION
This fixes compatibility with other NLTK tools currently deployed.  If we change over to using JSON output (which we should) then we need to do it for all tools.
